### PR TITLE
Fix for name with - in the name

### DIFF
--- a/Code/Classes/ansible.inventory.ps1
+++ b/Code/Classes/ansible.inventory.ps1
@@ -70,7 +70,7 @@ Class AnsibleInventory {
                 $GroupName = $matches[1]
             }
             ':children' { $record.HasChildren = $true }
-            '^[a-z0-9\._]+$' { 
+            '^[a-z0-9\._\-]+$' { 
                 $record.Members.Add($_)
                 if ($record.HasChildren -eq $false) {
 


### PR DESCRIPTION
I detected an issue 
If the name of the server in the inventory contain minus sign (-) adding it to the inventory failed with no error